### PR TITLE
Modification of process

### DIFF
--- a/decision-process.md
+++ b/decision-process.md
@@ -28,13 +28,19 @@ reified and talked upon, rather than hidden behind individual initiatives.
       * must have a strict majority of votes "no"
       * AND must have gathered at least three vote "no"
 
-   One can vote "blank" which means "half-yes, half-no", in which case it's not counted.
-
    If there are insufficient votes, or if no one wants to merge/reject yet, the period 
-   of voting is extended with a maximum of one month. It is rejected due to lack of interest.
+   of voting is extended for 24h, with a maximum of one month. 
+   After that duration, it is rejected due to lack of interest.
 
-5. A proposal cannot be merged or rejected by the same person making the proposal.
+5. One can vote "yes-if(X)" or "no-if(X)" to a proposal which mean the vote counts as a "yes" 
+   if the Proposal's submitter answers the concern of the voter, and a "no" instead.
+   This is meant for clarification. Reviewers are trusted to compute X in an impartial way.
+   The yes-if and no-if variants of votes have to be managed through Github reviews.
+   In the case of a single voter having several Github reviews, whose result is conflicting, 
+   the "no" wins.
 
-6. A proposal being merged or rejected doesn't mean the debate is closed.
+6. A proposal cannot be merged or rejected by the same person making the proposal.
 
-7. This document is self-referential. Process modifications themselves must follow this document.
+7. A proposal being merged or rejected doesn't mean the debate is closed.
+
+8. This document is self-referential. Process modifications themselves must follow this document.

--- a/decision-process.md
+++ b/decision-process.md
@@ -12,15 +12,29 @@ reified and talked upon, rather than hidden behind individual initiatives.
 2. Members of the Github organization DlangGraphicsWG have no special rights, 
    apart from being able to merge/reject Pull Requests according to this document.
 
-3. Modifications proposals to the Output are brought in through Pull Requests.
+3. Modifications proposals to the Output (.md files) are brought in through Pull Requests.
 
-4. Voting is open to anyone, as long as the PR is currently open, for a period of at least 24h.
-   After this time, a member of the Github Organization is allowed to merge or reject the Pull Request as long as the PR is still open by its author
+4. Each open Pull Request is a vote to be held. 
+
+   Voting is open to anyone, as long as the PR is currently open, for a period of at least 24h.
+   After this time, a member of the Github Organization is allowed to merge or reject the Pull Request.
    
-   For being merged a proposal:
-      * must have a strict majority of votes
-      * must have gathered at least three vote "yes"
+   For being merged, a proposal:
+      * must have a strict majority of votes "yes"
+      * AND must have gathered at least three vote "yes"
+      * must still be open by its author
 
-   As such, each open Pull Request is a vote to be held.
+   For being rejected, a proposal:
+      * must have a strict majority of votes "no"
+      * AND must have gathered at least three vote "no"
 
-5. This document is self-referential. Process modifications themselves must follow this document.
+   One can vote "blank" which means "half-yes, half-no", in which case it's not counted.
+
+   If there are insufficient votes, or if no one wants to merge/reject yet, the period 
+   of voting is extended with a maximum of one month. It is rejected due to lack of interest.
+
+5. A proposal cannot be merged or rejected by the same person making the proposal.
+
+6. A proposal being merged or rejected doesn't mean the debate is closed.
+
+7. This document is self-referential. Process modifications themselves must follow this document.


### PR DESCRIPTION
This proposal brings modification to the process which I believe are needed:

- "A proposal cannot be merged or rejected by the same person making the proposal."

- clarify what leads to ACCEPTED or REJECTED

- clarify that a debate isn't closed after a Proposal has been accepted or rejected

- ~~introduce "blank" votes, which are useful in the case of one PR with several votes~~

- yes-if and no-if votes, which are tied to the Github 

Please vote !